### PR TITLE
Fix PackageSecurityHealthCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix PackageSecurityHealthCheck by using the `enlightn/security-checker` package instead of the archived `sensiolabs/security-checker` package
+
 ## [1.13.1] - 2021-10-13
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,6 @@
         "illuminate/redis": "Allows the redis health check to function.",
         "league/flysystem": "Allows the ftp health check to function.",
         "guzzlehttp/guzzle": "Allows the http health check to function.",
-        "sensiolabs/security-checker": "Allows the package security health check to function."
+        "enlightn/security-checker": "Allows the package security health check to function."
     }
 }

--- a/config/healthcheck.php
+++ b/config/healthcheck.php
@@ -108,10 +108,11 @@ return [
     ],
 
     /*
-     * A list of packages to be ignored by the Package Security health check
+     * Settings for the Package Security health check
      */
     'package-security' => [
-        'ignore' => [],
+        'exclude-dev' => false, // Exclude dev dependencies from the security check
+        'ignore' => [], // Packages to ignore
     ],
 
     'scheduler' => [
@@ -121,7 +122,7 @@ return [
 
     /*
      * Default value for env checks.
-     * For each key, the check will call `env(KEY, config('healthcheck.env-default-key'))` 
+     * For each key, the check will call `env(KEY, config('healthcheck.env-default-key'))`
      * to avoid false positives when `env(KEY)` is defined but is null.
      */
     'env-check-key' => 'HEALTH_CHECK_ENV_DEFAULT_VALUE',

--- a/tests/json/securityCheckerPackageHasVulnerability.json
+++ b/tests/json/securityCheckerPackageHasVulnerability.json
@@ -1,6 +1,7 @@
 {
     "example/package": {
-        "version": "v1.2.3",
+        "version": "1.2.3",
+        "time": "2021-10-01T00:00:00+00:00",
         "advisories": [
             {
                 "title": "Example Vulnerability",


### PR DESCRIPTION
Resolves #63.

Swaps `sensiolabs/security-checker` for `enlightn/security-checker`.

If `enlightn/security-checker` is not installed, but `sensiolabs/security-checker` is, the check will return as a problem with a notice to swap the packages. The check would already be returning a problem (regardless of package vulnerability status) since the sensiolabs API no longer functions.