### PR TITLE
Tweak A Typehint

### DIFF
--- a/src/HealthCheck.php
+++ b/src/HealthCheck.php
@@ -2,7 +2,7 @@
 
 namespace UKFast\HealthCheck;
 
-use Exception;
+use \Throwable;
 
 abstract class HealthCheck
 {
@@ -39,7 +39,7 @@ abstract class HealthCheck
             ->withName($this->name());
     }
 
-    protected function exceptionContext(Exception $e)
+    protected function exceptionContext(Throwable $e)
     {
         return [
             'error' => $e->getMessage(),


### PR DESCRIPTION
Exception extends throwable and this function only uses functions defined in throwable. I hit this error when trying to catch Guzzle exceptions as it and Laravel are moving to the Throwable superclass