### PR TITLE
adding more entropy to the uniqid in the storagehealthcheck

### DIFF
--- a/src/Checks/StorageHealthCheck.php
+++ b/src/Checks/StorageHealthCheck.php
@@ -18,7 +18,7 @@ class StorageHealthCheck extends HealthCheck
 
     public function status()
     {
-        $uniqueString = uniqid('laravel-health-check_');
+        $uniqueString = uniqid('laravel-health-check_', true);
 
         foreach (config('healthcheck.storage.disks') as $disk) {
             try {


### PR DESCRIPTION
php uniqid does not guarantee uniq ids in storage healthcheck.. that produces in my project failing checks.. the problem is about concurrency.. when the infrastructure is fast enough you can create same uniqid for diferent checks in the same microsec.. causing the misinformation

https://www.php.net/manual/en/function.uniqid.php#120123