### PR TITLE
Stop PHPUnit 10 being installed till we can fix deprecation errors in v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "nesbot/carbon": "^1.26.3|^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.0",
+        "phpunit/phpunit": ">=5.0 <10",
         "orchestra/testbench": "^3.0|^4.0|^5.0|^6.0|^8.0",
         "mockery/mockery": "^1.0",
         "illuminate/database": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0",

--- a/src/Status.php
+++ b/src/Status.php
@@ -19,6 +19,9 @@ class Status
     /** @var string */
     protected $message = '';
 
+    /** @var array */
+    protected $context = [];
+
     /**
      * Marks the status as a problem
      * 


### PR DESCRIPTION
https://phpunit.de/announcements/phpunit-10.html

There's a bigger piece of work around supporting PHPUnit 10 so for now I think it's fine for us to stay on v9.

We should probably look at what PHP versions we want to support moving forwards and set up our testing dependency versions based on that.