### PR TITLE
Config. default-problem-http-code for Controller

### DIFF
--- a/config/healthcheck.php
+++ b/config/healthcheck.php
@@ -78,6 +78,12 @@ return [
     'default-response-code' => 200,
 
     /*
+     * Default code for HTTP health check when there any problem occured.
+     * Will be used in the HealthCheckController's response.
+     */
+    'default-problem-http-code' => 500,
+    
+    /*
      * Default timeout for cURL requests for HTTP health check.
      */
     'default-curl-timeout' => 2.0,

--- a/src/Controllers/HealthCheckController.php
+++ b/src/Controllers/HealthCheckController.php
@@ -42,6 +42,6 @@ class HealthCheckController
             }
         }
 
-        return new Response($body, $isProblem ? config('healthcheck.default-problem-http-code') : 200);
+        return new Response($body, $isProblem ? config('healthcheck.default-problem-http-code', 500) : 200);
     }
 }

--- a/src/Controllers/HealthCheckController.php
+++ b/src/Controllers/HealthCheckController.php
@@ -42,6 +42,6 @@ class HealthCheckController
             }
         }
 
-        return new Response($body, $isProblem ? 500 : 200);
+        return new Response($body, $isProblem ? config('healthcheck.default-problem-http-code') : 200);
     }
 }


### PR DESCRIPTION
This gives much more flexibility to manage the response http code. For example, the most clear way for me to respond with 417 code, as app actually runs well. It does not care of 3xx, 4xx, 5xx.... on any onther endpoint I made check up. But if package or app fails then that the moment for me where 500 may take place. Anyway, it is left default as 500, so, nothing affected negatively. 