### PR TITLE
Fix package security check

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,6 +43,7 @@ jobs:
                   rm -f composer.lock
                   sudo composer self-update
                   composer require laravel/framework:^${{ matrix.environment.laravel_version }}.0 -W
+                  composer require enlightn/security-checker
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped support for < Laravel 10 **(breaking change)**
 - The `context` property for `UKFast\HealthCheck\Checks\CrossServiceHealthCheck` is now an array, not a string, matching other checks **(breaking change)**
 
+### Fixed
+
+- Fix PackageSecurityHealthCheck by using the `enlightn/security-checker` package instead of the archived `sensiolabs/security-checker` package **(breaking change)**
+
 ## [1.15.0] - 2024-07-17
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
+        "enlightn/security-checker": "^2.0",
         "illuminate/console": "^10.0|^11.0",
         "illuminate/http": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0"
@@ -76,6 +77,6 @@
         "illuminate/redis": "Allows the redis health check to function.",
         "league/flysystem": "Allows the ftp health check to function.",
         "guzzlehttp/guzzle": "Allows the http health check to function.",
-        "sensiolabs/security-checker": "Allows the package security health check to function."
+        "enlightn/security-checker": "Allows the package security health check to function."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "enlightn/security-checker": "^2.0",
         "illuminate/console": "^10.0|^11.0",
         "illuminate/http": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0"

--- a/config/healthcheck.php
+++ b/config/healthcheck.php
@@ -82,7 +82,7 @@ return [
      * Will be used in the HealthCheckController's response.
      */
     'default-problem-http-code' => 500,
-    
+
     /*
      * Default timeout for cURL requests for HTTP health check.
      */
@@ -114,10 +114,11 @@ return [
     ],
 
     /*
-     * A list of packages to be ignored by the Package Security health check
+     * Settings for the Package Security health check
      */
     'package-security' => [
-        'ignore' => [],
+        'exclude-dev' => false, // Exclude dev dependencies from the security check
+        'ignore' => [], // Packages to ignore
     ],
 
     'scheduler' => [
@@ -127,7 +128,7 @@ return [
 
     /*
      * Default value for env checks.
-     * For each key, the check will call `env(KEY, config('healthcheck.env-default-key'))` 
+     * For each key, the check will call `env(KEY, config('healthcheck.env-default-key'))`
      * to avoid false positives when `env(KEY)` is defined but is null.
      */
     'env-check-key' => 'HEALTH_CHECK_ENV_DEFAULT_VALUE',

--- a/src/Checks/PackageSecurityHealthCheck.php
+++ b/src/Checks/PackageSecurityHealthCheck.php
@@ -48,7 +48,7 @@ class PackageSecurityHealthCheck extends HealthCheck
 
             $vulnerabilities = collect($result);
 
-            if ($vulnerabilities->count() > 0) {
+            if ($vulnerabilities->isNotEmpty()) {
                 $this->vulnerablePackages = $vulnerabilities->reject(function ($vulnerability, $package) {
                     return in_array($package, config('healthcheck.package-security.ignore'));
                 });

--- a/tests/Checks/PackageSecurityHealthCheckTest.php
+++ b/tests/Checks/PackageSecurityHealthCheckTest.php
@@ -36,30 +36,43 @@ class PackageSecurityHealthCheckTest extends TestCase
 
     public function testShowsProblemIfRequiredPackageNotLoaded()
     {
-        $status = (new PackageSecurityHealthCheck($this->app))->status();
+        $status = (new MockedPackageSecurityHealthCheck)->status();
 
         $this->assertTrue($status->isProblem());
+        $this->assertSame('You need to install the enlightn/security-checker package to use this check.', $status->context()['exception']['error']);
     }
 
-    public function shows_problem_if_cannot_check_packages(): void
+    public function testShowsProblemIfIncorrectPackageLoaded(): void
     {
-        $this->partialMock('overload:SensioLabs\Security\SecurityChecker', function ($mock) {
-            $mock->shouldReceive('check')->andThrow(new Exception('Lock file does not exist.'));
+        MockedPackageSecurityHealthCheck::$classResults = [
+            'Enlightn\SecurityChecker\SecurityChecker' => false,
+            'SensioLabs\Security\SecurityChecker' => true,
+        ];
+        $status = (new MockedPackageSecurityHealthCheck)->status();
+
+        $this->assertTrue($status->isProblem());
+        $this->assertSame('The sensiolabs/security-checker package has been archived. Install enlightn/security-checker instead.', $status->context()['exception']['error']);
+    }
+
+    public function testShowsProblemIfCannotCheckPackages(): void
+    {
+        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', function ($mock) {
+            $mock->shouldReceive('check')->andThrow(new Exception('File not found at [/tmp/composer.lock]'));
         });
 
-        $status = (new PackageSecurityHealthCheck($this->app))->status();
+        $status = (new PackageSecurityHealthCheck)->status();
 
         $this->assertTrue($status->isProblem());
     }
 
     public function testShowsProblemIfPackageHasVulnerability(): void
     {
-        $this->partialMock('overload:SensioLabs\Security\SecurityChecker', function ($mock) {
+        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', function ($mock) {
             $mock->shouldReceive('check')
-                ->andReturn(new MockResult(1, file_get_contents('tests/json/sensiolabsPackageHasVulnerability.json')));
+                ->andReturn(json_decode(file_get_contents('tests/json/securityCheckerPackageHasVulnerability.json'), true));
         });
 
-        $status = (new PackageSecurityHealthCheck($this->app))->status();
+        $status = (new PackageSecurityHealthCheck)->status();
 
         $this->assertTrue($status->isProblem());
     }
@@ -72,44 +85,38 @@ class PackageSecurityHealthCheckTest extends TestCase
             ],
         ]);
 
-        $this->partialMock('overload:SensioLabs\Security\SecurityChecker', function ($mock) {
+        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', function ($mock) {
             $mock->shouldReceive('check')
-                ->andReturn(new MockResult(1, file_get_contents('tests/json/sensiolabsPackageHasVulnerability.json')));
+                ->andReturn(json_decode(file_get_contents('tests/json/securityCheckerPackageHasVulnerability.json'), true));
         });
 
-        $status = (new PackageSecurityHealthCheck($this->app))->status();
+        $status = (new PackageSecurityHealthCheck)->status();
 
         $this->assertTrue($status->isOkay());
     }
 
     public function testShowsOkayIfNoPackagesHaveVulnerabilities(): void
     {
-        $this->partialMock('overload:SensioLabs\Security\SecurityChecker', function ($mock) {
+        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', function ($mock) {
             $mock->shouldReceive('check')
-                ->andReturn(new MockResult(0, '{}'));
+                ->andReturn([]);
         });
 
-        $status = (new PackageSecurityHealthCheck($this->app))->status();
+        $status = (new PackageSecurityHealthCheck)->status();
 
         $this->assertTrue($status->isOkay());
     }
 }
 
-class MockResult
+class MockedPackageSecurityHealthCheck extends \UKFast\HealthCheck\Checks\PackageSecurityHealthCheck
 {
-    public function __construct(
-        public readonly int $count,
-        private readonly string $vulnerabilities,
-    ) {
-    }
+    public static $classResults = [
+        'Enlightn\SecurityChecker\SecurityChecker' => false,
+        'SensioLabs\Security\SecurityChecker' => false,
+    ];
 
-    public function __toString(): string
+    public static function checkDependency(string $class): bool
     {
-        return $this->vulnerabilities;
-    }
-
-    public function count(): int
-    {
-        return $this->count;
+        return static::$classResults[$class];
     }
 }

--- a/tests/Checks/PackageSecurityHealthCheckTest.php
+++ b/tests/Checks/PackageSecurityHealthCheckTest.php
@@ -56,9 +56,9 @@ class PackageSecurityHealthCheckTest extends TestCase
 
     public function testShowsProblemIfCannotCheckPackages(): void
     {
-        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', function ($mock) {
-            $mock->shouldReceive('check')->andThrow(new Exception('File not found at [/tmp/composer.lock]'));
-        });
+        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', fn (MockInterface $mock) =>
+            $mock->shouldReceive('check')->andThrow(new Exception('File not found at [/tmp/composer.lock]'))
+        );
 
         $status = (new PackageSecurityHealthCheck)->status();
 
@@ -67,10 +67,10 @@ class PackageSecurityHealthCheckTest extends TestCase
 
     public function testShowsProblemIfPackageHasVulnerability(): void
     {
-        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', function ($mock) {
+        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', fn (MockInterface $mock) =>
             $mock->shouldReceive('check')
-                ->andReturn(json_decode(file_get_contents('tests/json/securityCheckerPackageHasVulnerability.json'), true));
-        });
+                ->andReturn(json_decode(file_get_contents('tests/json/securityCheckerPackageHasVulnerability.json'), true))
+        );
 
         $status = (new PackageSecurityHealthCheck)->status();
 
@@ -85,10 +85,10 @@ class PackageSecurityHealthCheckTest extends TestCase
             ],
         ]);
 
-        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', function ($mock) {
+        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', fn (MockInterface $mock) =>
             $mock->shouldReceive('check')
-                ->andReturn(json_decode(file_get_contents('tests/json/securityCheckerPackageHasVulnerability.json'), true));
-        });
+                ->andReturn(json_decode(file_get_contents('tests/json/securityCheckerPackageHasVulnerability.json'), true))
+        );
 
         $status = (new PackageSecurityHealthCheck)->status();
 
@@ -97,10 +97,10 @@ class PackageSecurityHealthCheckTest extends TestCase
 
     public function testShowsOkayIfNoPackagesHaveVulnerabilities(): void
     {
-        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', function ($mock) {
+        $this->partialMock('overload:Enlightn\SecurityChecker\SecurityChecker', fn(MockInterface $mock) =>
             $mock->shouldReceive('check')
-                ->andReturn([]);
-        });
+                ->andReturn([])
+        );
 
         $status = (new PackageSecurityHealthCheck)->status();
 
@@ -108,9 +108,12 @@ class PackageSecurityHealthCheckTest extends TestCase
     }
 }
 
-class MockedPackageSecurityHealthCheck extends \UKFast\HealthCheck\Checks\PackageSecurityHealthCheck
+class MockedPackageSecurityHealthCheck extends PackageSecurityHealthCheck
 {
-    public static $classResults = [
+    /**
+     * @var array<string, bool>
+     */
+    public static array $classResults = [
         'Enlightn\SecurityChecker\SecurityChecker' => false,
         'SensioLabs\Security\SecurityChecker' => false,
     ];

--- a/tests/json/securityCheckerPackageHasVulnerability.json
+++ b/tests/json/securityCheckerPackageHasVulnerability.json
@@ -1,6 +1,7 @@
 {
     "example/package": {
-        "version": "v1.2.3",
+        "version": "1.2.3",
+        "time": "2021-10-01T00:00:00+00:00",
         "advisories": [
             {
                 "title": "Example Vulnerability",


### PR DESCRIPTION
Resolves #63.

Moving from sensiolab to enlightn because sensiolab is abandoned.

Original PR:
https://github.com/ans-group/laravel-health-check/pull/64

