### PR TITLE
Fix ftp check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
         "ext-json": "*",
         "illuminate/console": "^10.0|^11.0",
         "illuminate/http": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0"
+        "illuminate/support": "^10.0|^11.0",
+        "league/flysystem-ftp": "^3.28"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0|^11.0",
@@ -75,6 +76,7 @@
         "illuminate/log": "Allows the log health check to function.",
         "illuminate/redis": "Allows the redis health check to function.",
         "league/flysystem": "Allows the ftp health check to function.",
+        "league/flysystem-ftp": "Allows the ftp health check to function.",
         "guzzlehttp/guzzle": "Allows the http health check to function.",
         "enlightn/security-checker": "Allows the package security health check to function."
     }

--- a/src/Checks/FtpHealthCheck.php
+++ b/src/Checks/FtpHealthCheck.php
@@ -2,7 +2,8 @@
 
 namespace UKFast\HealthCheck\Checks;
 
-use League\Flysystem\Adapter\Ftp;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\Ftp\FtpAdapter;
 use UKFast\HealthCheck\HealthCheck;
 use UKFast\HealthCheck\Status;
 
@@ -10,23 +11,18 @@ class FtpHealthCheck extends HealthCheck
 {
     protected string $name = 'ftp';
 
-    /**
-     * @var \Illuminate\Contracts\Filesystem\Filesystem
-     */
-    protected $ftp;
-
-    public function __construct(Ftp $ftp)
-    {
-        $this->ftp = $ftp;
+    public function __construct(
+        protected FtpAdapter $ftpAdapter,
+    ) {
     }
 
     public function status(): Status
     {
         try {
-            $this->ftp->getConnection();
-        } catch (\RuntimeException $e) {
+            $this->ftpAdapter->listContents('', false);
+        } catch (FilesystemException $exception) {
             return $this->problem('Could not connect to FTP server', [
-                'exception' => $this->exceptionContext($e),
+                'exception' => $this->exceptionContext($exception),
             ]);
         }
 

--- a/src/HealthCheck.php
+++ b/src/HealthCheck.php
@@ -42,14 +42,14 @@ abstract class HealthCheck
     /**
      * @return array<string, string|array|int>
      */
-    protected function exceptionContext(Exception $e): array
+    protected function exceptionContext(Exception $exception): array
     {
         return [
-            'error' => $e->getMessage(),
-            'class' => get_class($e),
-            'line' => $e->getLine(),
-            'file' => $e->getFile(),
-            'trace' => explode("\n", $e->getTraceAsString()),
+            'error' => $exception->getMessage(),
+            'class' => get_class($exception),
+            'line' => $exception->getLine(),
+            'file' => $exception->getFile(),
+            'trace' => explode("\n", $exception->getTraceAsString()),
         ];
     }
 }

--- a/src/HealthCheck.php
+++ b/src/HealthCheck.php
@@ -2,7 +2,7 @@
 
 namespace UKFast\HealthCheck;
 
-use Exception;
+use Throwable;
 
 abstract class HealthCheck
 {
@@ -42,7 +42,7 @@ abstract class HealthCheck
     /**
      * @return array<string, string|array|int>
      */
-    protected function exceptionContext(Exception $exception): array
+    protected function exceptionContext(Throwable $exception): array
     {
         return [
             'error' => $exception->getMessage(),

--- a/tests/Checks/FtpHealthCheckTest.php
+++ b/tests/Checks/FtpHealthCheckTest.php
@@ -2,38 +2,44 @@
 
 namespace Tests\Unit\HealthCheck;
 
+use League\Flysystem\Ftp\FtpAdapter;
+use League\Flysystem\Ftp\UnableToConnectToFtpHost;
 use UKFast\HealthCheck\Checks\FtpHealthCheck;
-use RuntimeException;
-use League\Flysystem\Adapter\Ftp;
 use Tests\TestCase;
-use Mockery as m;
+use Mockery;
 
 class FtpHealthCheckTest extends TestCase
 {
     public function testShowsProblemWhenCantConnectToFtpServer(): void
     {
-        $ftp = m::mock(Ftp::class)
-            ->expects('getConnection')
-            ->andThrow(new RuntimeException('uwu'))
+        $ftp = Mockery::mock(FtpAdapter::class)
+            ->expects('listContents')
+            ->andThrow(new  UnableToConnectToFtpHost('uwu'))
             ->getMock();
 
         $status = (new FtpHealthCheck($ftp))->status();
 
         $this->assertTrue($status->isProblem());
 
-        m::close();
+        Mockery::close();
     }
 
     public function testShowsOkayWhenCanConnectToFtpServer(): void
     {
-        $ftp = m::mock(Ftp::class)
-            ->expects('getConnection')
-            ->andReturn(true)
+        function generator(): iterable {
+            yield 'foo';
+            yield 'bar';
+            yield 'baz';
+        };
+
+        $ftp = Mockery::mock(FtpAdapter::class)
+            ->expects('listContents')
+            ->andReturn(generator())
             ->getMock();
 
         $status = (new FtpHealthCheck($ftp))->status();
         $this->assertTrue($status->isOkay());
 
-        m::close();
+        Mockery::close();
     }
 }


### PR DESCRIPTION
Laravel 11 specifies v3 of flysystem and the current implementation of this was for v1. v2 saw a refactor that has affected this check, so we need to update this.