### PR TITLE
Bump Larastan to level 4

### DIFF
--- a/.phpmd/ruleset.xml
+++ b/.phpmd/ruleset.xml
@@ -16,7 +16,18 @@
         <exclude name="StaticAccess" />
     </rule>
 
-    <rule ref="rulesets/codesize.xml" />
+    <rule ref="rulesets/codesize.xml">
+        <!-- We don't want to limit public methods on tests -->
+        <exclude name="TooManyPublicMethods" />
+    </rule>
+
+    <rule ref="rulesets/codesize.xml/TooManyPublicMethods">
+        <properties>
+            <!-- Ignore test and the "with" set methods as well as the default ignores -->
+            <property name="ignorepattern" value="/^(test|set|get|with)/i" />
+        </properties>
+    </rule>
+
 
     <rule ref="rulesets/controversial.xml" />
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-    level: 3
+    level: 4
 
     paths:
         - config

--- a/src/Checks/MigrationUpToDateHealthCheck.php
+++ b/src/Checks/MigrationUpToDateHealthCheck.php
@@ -10,7 +10,7 @@ class MigrationUpToDateHealthCheck extends HealthCheck
 {
     protected string $name = 'migration';
 
-    protected Migrator $migrator;
+    protected Migrator|null $migrator;
 
     public function status(): Status
     {

--- a/src/Checks/MigrationUpToDateHealthCheck.php
+++ b/src/Checks/MigrationUpToDateHealthCheck.php
@@ -10,7 +10,7 @@ class MigrationUpToDateHealthCheck extends HealthCheck
 {
     protected string $name = 'migration';
 
-    protected Migrator|null $migrator;
+    protected Migrator|null $migrator = null;
 
     public function status(): Status
     {

--- a/tests/Checks/RedisHealthCheckTest.php
+++ b/tests/Checks/RedisHealthCheckTest.php
@@ -184,6 +184,7 @@ class RedisHealthCheckTest extends TestCase
                 1 => [['master1', '6379']],
                 2 => [['master2', '6379']],
                 3 => [['master3', '6379']],
+                default => throw new Exception("unexpected invocation"),
             })
             ->willReturn('pong');
 
@@ -224,6 +225,7 @@ class RedisHealthCheckTest extends TestCase
             ->method('ping')
             ->willReturnCallback(fn(): array => match ($matcher->numberOfInvocations()) {
                 1 => [['master1', '6379']],
+                default => throw new Exception("unexpected invocation"),
             })
             ->willThrowException(new Exception("cannot connect to master1:6379"));
 
@@ -267,6 +269,7 @@ class RedisHealthCheckTest extends TestCase
                 1 => 'pong',
                 2 => 'pong',
                 3 => throw new Exception("cannot connect to master3:6379"),
+                default => throw new Exception("unexpected invocation"),
             });
 
         $redis = $this->createMock(RedisManager::class);


### PR DESCRIPTION
This is the next Larastan bump.

Level 4:
Basic dead code checking - always false instanceof and other type checks, dead else branches, unreachable code after return; etc.