### PR TITLE
Update Dependencies & Larastan Baseline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,23 +57,23 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "illuminate/console": "^10.0|^11.0",
-        "illuminate/http": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0"
+        "illuminate/console": "^10.0|^11.0|^12.0",
+        "illuminate/http": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/log": "^10.0|^11.0",
-        "illuminate/redis": "^10.0|^11.0",
-        "larastan/larastan": "^2.9",
+        "illuminate/database": "^10.0|^11.0|^12.0",
+        "illuminate/log": "^10.0|^11.0|^12.0",
+        "illuminate/redis": "^10.0|^11.0|^12.0",
+        "larastan/larastan": "^3.1",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^8.0|^9.0",
         "phpmd/phpmd": "^2.15",
-        "phpstan/phpstan-mockery": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.4",
-        "phpunit/phpunit": "^10.0|^11.0",
-        "rector/rector": "^1.2",
+        "phpstan/phpstan-mockery": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
+        "rector/rector": "^2.0",
         "squizlabs/php_codesniffer": "^3.10"
     },
     "suggest": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,3 +34,83 @@ parameters:
         - message: '#Call to method .+ on an unknown class Enlightn\\SecurityChecker\\SecurityChecker#'
           paths:
             - src/Checks/PackageSecurityHealthCheck.php
+
+        # Updated baseline for Larastan ^3.0
+
+        -
+          message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+          identifier: larastan.noEnvCallsOutsideOfConfig
+          count: 2
+          path: config/healthcheck.php
+
+        -
+          message: '#^Loose comparison using \!\= between ''broken'' and ''healthy'' will always evaluate to true\.$#'
+          identifier: notEqual.alwaysTrue
+          count: 1
+          path: src/Checks/CacheHealthCheck.php
+
+        -
+          message: '#^Unreachable statement \- code above always terminates\.$#'
+          identifier: deadCode.unreachable
+          count: 1
+          path: src/Checks/CacheHealthCheck.php
+
+        -
+          message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+          identifier: larastan.noEnvCallsOutsideOfConfig
+          count: 1
+          path: src/Checks/EnvHealthCheck.php
+
+        -
+          message: '#^Parameter \#2 \$value of method Illuminate\\Support\\Collection\<string,array\<string, string\>\>\:\:put\(\) expects array\<string, string\>, array\<string, mixed\> given\.$#'
+          identifier: argument.type
+          count: 1
+          path: src/Checks/HttpHealthCheck.php
+
+        -
+          message: '#^Property UKFast\\HealthCheck\\Checks\\PackageSecurityHealthCheck\:\:\$vulnerablePackages \(Illuminate\\Support\\Collection\<int, string\>\) does not accept Illuminate\\Support\\Collection\<string, array\<string, string\>\|string\>\.$#'
+          identifier: assign.propertyType
+          count: 1
+          path: src/Checks/PackageSecurityHealthCheck.php
+
+        -
+          message: '#^Offset 0 does not exist on non\-empty\-array\<string, array\<string, int\|string\>\|Psr\\Http\\Message\\RequestInterface\|string\|null\>\.$#'
+          identifier: offsetAccess.notFound
+          count: 4
+          path: tests/Checks/CrossServiceHealthCheckTest.php
+
+        -
+          message: '#^Parameter &\$container by\-ref type of method Tests\\Checks\\CrossServiceHealthCheckTest\:\:mockClient\(\) expects array\<string, array\<string, int\|string\>\|Psr\\Http\\Message\\RequestInterface\|string\|null\>, array\|ArrayAccess\<int, array\> given\.$#'
+          identifier: parameterByRef.type
+          count: 1
+          path: tests/Checks/CrossServiceHealthCheckTest.php
+
+        -
+          message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
+          identifier: method.alreadyNarrowedType
+          count: 1
+          path: tests/Commands/CacheSchedulerRunningTest.php
+
+        -
+          message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with Illuminate\\Routing\\Route will always evaluate to true\.$#'
+          identifier: method.alreadyNarrowedType
+          count: 3
+          path: tests/HealthCheckServiceProviderTest.php
+
+        -
+          message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with string will always evaluate to true\.$#'
+          identifier: method.alreadyNarrowedType
+          count: 1
+          path: tests/HealthCheckServiceProviderTest.php
+
+        -
+          message: '#^PHPDoc tag @SuppressWarnings has invalid value \(\(PHPMD\.CamelCaseMethodName\)\)\: Unexpected token "\.CamelCaseMethodName\)", expected ''\)'' at offset 219 on line 5$#'
+          identifier: phpDoc.parseError
+          count: 1
+          path: tests/Stubs/Redis/Connections/PhpRedisClusterConnection.php
+
+        -
+          message: '#^PHPDoc tag @SuppressWarnings has invalid value \(\(PHPMD\.UnusedLocalVariable\)\)\: Unexpected token "\.UnusedLocalVariable\)", expected ''\)'' at offset 167 on line 4$#'
+          identifier: phpDoc.parseError
+          count: 1
+          path: tests/Stubs/Redis/Connections/PhpRedisClusterConnection.php


### PR DESCRIPTION
In trying to upgrade to Laravel 12 I was hit with some problems because of the dependency requirements in this package.  I went through and updated dependencies so that it would be possible to upgrade Laravel and keep using this package.  Larastan started throwing more errors, so I updated the baseline since there were no code changes.  The list of errors I saw before/after the upgrade are:

Pre upgrade errors:
```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Checks/FtpHealthCheck.php                                                                                                              
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  15     Parameter $ftpAdapter of method UKFast\HealthCheck\Checks\FtpHealthCheck::__construct() has invalid type League\Flysystem\Ftp\FtpAdapter.  
  15     Property UKFast\HealthCheck\Checks\FtpHealthCheck::$ftpAdapter has unknown class League\Flysystem\Ftp\FtpAdapter as its type.              
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols                                                                        
  22     Call to method listContents() on an unknown class League\Flysystem\Ftp\FtpAdapter.                                                         
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols                                                                        
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Checks/PackageSecurityHealthCheck.php                                                                                                                                                                             
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  59     Property UKFast\HealthCheck\Checks\PackageSecurityHealthCheck::$vulnerablePackages (Illuminate\Support\Collection<int, string>) does not accept Illuminate\Support\Collection<string, array<string, string>|string>.  
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------- 
  Line   tests/Checks/FtpHealthCheckTest.php                                            
 ------ ------------------------------------------------------------------------------- 
  15     Class League\Flysystem\Ftp\FtpAdapter not found.                               
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols            
  16     Call to method expects() on an unknown class League\Flysystem\Ftp\FtpAdapter.  
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols            
  17     Instantiated class League\Flysystem\Ftp\UnableToConnectToFtpHost not found.    
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols            
  34     Class League\Flysystem\Ftp\FtpAdapter not found.                               
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols            
  35     Call to method expects() on an unknown class League\Flysystem\Ftp\FtpAdapter.  
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols            
 ------ ------------------------------------------------------------------------------- 
 ```

Post upgrade errors:
```
 ------ ---------------------------------------------------------------------------------------------------------- 
  Line   config/healthcheck.php                                                                                    
 ------ ---------------------------------------------------------------------------------------------------------- 
  41     Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.  
         🪪  larastan.noEnvCallsOutsideOfConfig                                                                    
  42     Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.  
         🪪  larastan.noEnvCallsOutsideOfConfig                                                                    
 ------ ---------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Checks/CacheHealthCheck.php                                                                                                                  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 
  41     Loose comparison using != between 'broken' and 'healthy' will always evaluate to true.                                                           
         🪪  notEqual.alwaysTrue                                                                                                                          
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.dist.  
  49     Unreachable statement - code above always terminates.                                                                                            
         🪪  deadCode.unreachable                                                                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------- 
  Line   src/Checks/EnvHealthCheck.php                                                                             
 ------ ---------------------------------------------------------------------------------------------------------- 
  18     Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.  
         🪪  larastan.noEnvCallsOutsideOfConfig                                                                    
 ------ ---------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Checks/HttpHealthCheck.php                                                                                                                               
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  62     Parameter #2 $value of method Illuminate\Support\Collection<string,array<string, string>>::put() expects array<string, string>, array<string, mixed> given.  
         🪪  argument.type                                                                                                                                            
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Checks/PackageSecurityHealthCheck.php                                                                                                                                                                             
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  59     Property UKFast\HealthCheck\Checks\PackageSecurityHealthCheck::$vulnerablePackages (Illuminate\Support\Collection<int, string>) does not accept Illuminate\Support\Collection<string, array<string, string>|string>.  
         🪪  assign.propertyType                                                                                                                                                                                               
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/Checks/CrossServiceHealthCheckTest.php                                                                                                                                                                                             
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  30     Offset 0 does not exist on non-empty-array<string, array<string, int|string>|Psr\Http\Message\RequestInterface|string|null>.                                                                                                             
         🪪  offsetAccess.notFound                                                                                                                                                                                                                
  31     Offset 0 does not exist on non-empty-array<string, array<string, int|string>|Psr\Http\Message\RequestInterface|string|null>.                                                                                                             
         🪪  offsetAccess.notFound                                                                                                                                                                                                                
  46     Offset 0 does not exist on non-empty-array<string, array<string, int|string>|Psr\Http\Message\RequestInterface|string|null>.                                                                                                             
         🪪  offsetAccess.notFound                                                                                                                                                                                                                
  47     Offset 0 does not exist on non-empty-array<string, array<string, int|string>|Psr\Http\Message\RequestInterface|string|null>.                                                                                                             
         🪪  offsetAccess.notFound                                                                                                                                                                                                                
  77     Parameter &$container by-ref type of method Tests\Checks\CrossServiceHealthCheckTest::mockClient() expects array<string, array<string, int|string>|Psr\Http\Message\RequestInterface|string|null>, array|ArrayAccess<int, array> given.  
         🪪  parameterByRef.type                                                                                                                                                                                                                  
         💡 You can change the parameter out type with @param-out PHPDoc tag.                                                                                                                                                                     
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------- 
  Line   tests/Commands/CacheSchedulerRunningTest.php                                                   
 ------ ----------------------------------------------------------------------------------------------- 
  22     Call to method PHPUnit\Framework\Assert::assertTrue() with true will always evaluate to true.  
         🪪  method.alreadyNarrowedType                                                                 
 ------ ----------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/HealthCheckServiceProviderTest.php                                                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 
  72     Call to method PHPUnit\Framework\Assert::assertNotNull() with Illuminate\Routing\Route will always evaluate to true.                             
         🪪  method.alreadyNarrowedType                                                                                                                   
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.dist.  
  84     Call to method PHPUnit\Framework\Assert::assertNotNull() with Illuminate\Routing\Route will always evaluate to true.                             
         🪪  method.alreadyNarrowedType                                                                                                                   
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.dist.  
  85     Call to method PHPUnit\Framework\Assert::assertNotNull() with Illuminate\Routing\Route will always evaluate to true.                             
         🪪  method.alreadyNarrowedType                                                                                                                   
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.dist.  
  104    Call to method PHPUnit\Framework\Assert::assertNotNull() with string will always evaluate to true.                                               
         🪪  method.alreadyNarrowedType                                                                                                                   
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.dist.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/Stubs/Redis/Connections/PhpRedisClusterConnection.php                                                                                                   
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  24     PHPDoc tag @SuppressWarnings has invalid value ((PHPMD.UnusedLocalVariable)): Unexpected token ".UnusedLocalVariable)", expected ')' at offset 167 on line 4  
         🪪  phpDoc.parseError                                                                                                                                         
  25     PHPDoc tag @SuppressWarnings has invalid value ((PHPMD.CamelCaseMethodName)): Unexpected token ".CamelCaseMethodName)", expected ')' at offset 219 on line 5  
         🪪  phpDoc.parseError                                                                                                                                         
```